### PR TITLE
fix: graceful shutdown, eager eviction, bind address config

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ The server handles CoAP message types automatically:
   `null`, no response is sent.
 - **RST** (reset) — cancels the matching exchange (removes cached response).
 
+### Panic Behavior
+
+Handler functions must not panic. A panic in any handler will terminate the
+server thread (or the entire process if it is the main thread). If your
+handler calls code that may fail, use `catch` to convert errors into an
+appropriate CoAP error response instead of allowing unwinding.
+
 ### Routing
 
 There is no built-in router. Inspect the request packet directly:
@@ -148,12 +155,18 @@ var server = try coapd.Server.init(allocator, .{
     .exchange_count = 256,   // max concurrent CON exchanges
     .well_known_core = null, // RFC 6690 discovery payload
     .thread_count = 1,       // server threads (SO_REUSEPORT)
+    .bind_address = "0.0.0.0", // IPv4 bind address
 }, handler);
 ```
 
 ### `port`
 
 UDP port to bind. Default: `5683` (CoAP standard port per RFC 7252).
+
+### `bind_address`
+
+IPv4 address to bind. Use `"127.0.0.1"` for loopback only, `"0.0.0.0"` for
+all interfaces. IPv6 is not yet supported. Default: `"0.0.0.0"`.
 
 ### `buffer_count`
 
@@ -229,7 +242,7 @@ handlers.
 var server = try coapd.Server.init(allocator, config, handler);
 defer server.deinit();
 
-// 2a. Run (blocking) — binds, spawns threads, loops forever.
+// 2a. Run (blocking) — binds, spawns threads, loops until stop().
 try server.run();
 
 // 2b. Or manual control:
@@ -237,6 +250,9 @@ try server.listen();       // bind socket, arm io_uring
 while (running) {
     try server.tick();     // process one batch of completions
 }
+
+// 3. Graceful shutdown — call from another thread or signal handler.
+server.stop();             // signals run() and all workers to exit
 ```
 
 The `tick()` method processes up to 256 completion events, calls the handler

--- a/src/Io.zig
+++ b/src/Io.zig
@@ -36,6 +36,9 @@ pub fn init(
     std.debug.assert(buffer_size > 0);
 
     // Ring must accommodate send + release_buffer per recv, plus overhead.
+    // Each received packet may generate up to 3 SQEs: release_buffer,
+    // send_msg response, and periodic provide_buffers. The 4x multiplier
+    // covers this worst case with headroom for the multishot recv SQE.
     const ring_entries: u16 = buffer_count *| 4;
     var ring = try linux.IoUring.init(ring_entries, 0);
     errdefer ring.deinit();
@@ -67,7 +70,13 @@ pub fn deinit(io: *Io, allocator: std.mem.Allocator) void {
 }
 
 /// Bind a UDP socket and register buffers with the kernel.
-pub fn setup(io: *Io, port: u16) !void {
+pub fn setup(io: *Io, port: u16, bind_address: []const u8) !void {
+    const address = try std.net.Address.parseIp(bind_address, port);
+
+    // Only IPv4 is supported; IPv6 requires larger sockaddr buffers
+    // throughout the recv/send paths.
+    if (address.any.family != posix.AF.INET) return error.UnsupportedAddressFamily;
+
     const fd = try posix.socket(
         posix.AF.INET,
         posix.SOCK.DGRAM,
@@ -83,7 +92,6 @@ pub fn setup(io: *Io, port: u16) !void {
     posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDBUF, &buf_size) catch {};
     posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.RCVBUF, &buf_size) catch {};
 
-    const address = try std.net.Address.parseIp("0.0.0.0", port);
     try posix.bind(fd, &address.any, address.getOsSockLen());
 
     for (io.iovecs, 0..) |*iov, i| {
@@ -220,9 +228,9 @@ test "SO_REUSEPORT allows two instances on same port" {
 
     var io1 = try Io.init(allocator, 4, 256);
     defer io1.deinit(allocator);
-    try io1.setup(port);
+    try io1.setup(port, "0.0.0.0");
 
     var io2 = try Io.init(allocator, 4, 256);
     defer io2.deinit(allocator);
-    try io2.setup(port);
+    try io2.setup(port, "0.0.0.0");
 }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -30,6 +30,8 @@ pub const Config = struct {
     /// Number of server threads. Each gets its own socket/ring/exchange pool.
     /// Kernel distributes packets via SO_REUSEPORT.
     thread_count: u16 = 1,
+    /// IPv4 address to bind. Use "127.0.0.1" for loopback only.
+    bind_address: []const u8 = "0.0.0.0",
 };
 
 allocator: std.mem.Allocator,
@@ -38,6 +40,7 @@ handler_fn: handler.HandlerFn,
 arena: std.heap.ArenaAllocator,
 config: Config,
 exchanges: Exchange,
+running: std.atomic.Value(bool),
 
 // Pre-allocated per-CQE response state.
 addrs_response: []linux.sockaddr,
@@ -107,6 +110,7 @@ pub fn init(
         .arena = std.heap.ArenaAllocator.init(allocator),
         .config = config,
         .exchanges = exchanges,
+        .running = std.atomic.Value(bool).init(true),
         .addrs_response = addrs_response,
         .msgs_response = msgs_response,
         .iovs_response = iovs_response,
@@ -130,7 +134,7 @@ pub fn deinit(server: *Server) void {
 /// Bind the socket, register buffers, and arm the multishot recv.
 /// After this returns the server is ready to accept packets.
 pub fn listen(server: *Server) !void {
-    try server.io.setup(server.config.port);
+    try server.io.setup(server.config.port, server.config.bind_address);
 
     server.msg_recv.name = &server.addr_recv;
     server.msg_recv.namelen = @sizeOf(linux.sockaddr);
@@ -138,6 +142,11 @@ pub fn listen(server: *Server) !void {
 
     try server.io.recv_multishot(&server.msg_recv);
     _ = try server.io.submit();
+}
+
+/// Signal the server and all worker threads to stop after the current tick.
+pub fn stop(server: *Server) void {
+    server.running.store(false, .release);
 }
 
 pub fn run(server: *Server) !void {
@@ -152,6 +161,7 @@ pub fn run(server: *Server) !void {
             server.allocator,
             server.config,
             server.handler_fn,
+            &server.running,
         });
     }
 
@@ -161,20 +171,23 @@ pub fn run(server: *Server) !void {
         if (server.config.thread_count > 1) "s" else "",
     });
 
-    while (true) {
+    while (server.running.load(.acquire)) {
         try server.tick();
     }
+
+    for (threads) |t| t.join();
 }
 
 fn run_worker(
     allocator: std.mem.Allocator,
     config: Config,
     handler_fn: handler.HandlerFn,
+    running: *std.atomic.Value(bool),
 ) void {
     var worker = Server.init(allocator, config, handler_fn) catch return;
     defer worker.deinit();
     worker.listen() catch return;
-    while (true) worker.tick() catch return;
+    while (running.load(.acquire)) worker.tick() catch return;
 }
 
 pub fn tick(server: *Server) !void {
@@ -183,11 +196,13 @@ pub fn tick(server: *Server) !void {
 
     const count = try server.io.wait_cqes(cqes[0..], 1);
     var recv_failed = false;
+    var recv_fail_count: u32 = 0;
     var processed: u32 = 0;
 
     for (cqes[0..count], 0..) |cqe, index| {
         if (Io.is_recv(&cqe) and !Io.is_success(&cqe)) {
             recv_failed = true;
+            recv_fail_count += 1;
             continue;
         }
         if (!Io.is_success(&cqe)) {
@@ -210,7 +225,7 @@ pub fn tick(server: *Server) !void {
     }
 
     if (recv_failed) {
-        log.warn("multishot recv failed, re-arming", .{});
+        log.warn("multishot recv failed ({d} in batch), re-arming", .{recv_fail_count});
         try server.io.recv_multishot(&server.msg_recv);
     }
 
@@ -330,7 +345,14 @@ fn handle_recv(
                 data_wire,
                 now,
             ) == null) {
-                log.warn("exchange pool full, cannot cache", .{});
+                // Try evicting expired entries before giving up.
+                const evicted = server.exchanges.evict_expired(now);
+                if (evicted > 0) {
+                    server.last_eviction_ns = now;
+                    _ = server.exchanges.insert(key, packet.msg_id, data_wire, now);
+                } else {
+                    log.warn("exchange pool full ({d} active), cannot cache", .{server.exchanges.count_active});
+                }
             }
         }
     } else if (is_con) {
@@ -353,12 +375,20 @@ fn handle_recv(
             packet.msg_id,
         );
         const now = std.time.nanoTimestamp();
-        _ = server.exchanges.insert(
+        if (server.exchanges.insert(
             key,
             packet.msg_id,
             data_wire,
             now,
-        );
+        ) == null) {
+            const evicted = server.exchanges.evict_expired(now);
+            if (evicted > 0) {
+                server.last_eviction_ns = now;
+                _ = server.exchanges.insert(key, packet.msg_id, data_wire, now);
+            } else {
+                log.warn("exchange pool full ({d} active), cannot cache", .{server.exchanges.count_active});
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `stop()` method for graceful shutdown via atomic flag; `run()` and workers check flag each tick and join threads on exit
- Add configurable `bind_address` in Config (IPv4 only, validated at setup)
- Eager exchange eviction on pool exhaustion: evict expired entries before giving up at both insert sites
- Improved buffer starvation logging with failure count per batch
- Document handler panic limitation and ring sizing strategy
- Document `bind_address` config option in README

## Test plan
- [x] `zig build test` passes
- [x] `zig build bench -Doptimize=ReleaseFast` shows no regression (~826K req/s, 0% loss)