### PR TITLE
fix bench hang, remove unnecessary register_buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ High-performance CoAP server library for Zig, built on Linux io_uring.
 - .well-known/core resource discovery (RFC 6690)
 - Simple handler interface: `fn(Request) ?Response`
 - Context handlers and error-handling wrappers (`safeWrap`)
-- ~800K req/s single-threaded on loopback (scales with threads/core)
+- ~840K req/s single-threaded, ~2.8M req/s multi-threaded on loopback
 
 ## Quick Start
 
@@ -237,7 +237,7 @@ processed, but during bursts the pool must absorb all arrivals between
 processing cycles. Set this to at least 2x your expected concurrent clients'
 send window. Default: `512`.
 
-Hard ceiling: 1024 (kernel `UIO_MAXIOV` limit for `register_buffers`).
+Higher values require more kernel memory per io_uring instance.
 
 ### `buffer_size`
 
@@ -411,25 +411,29 @@ Log messages:
 
 ## Benchmarks
 
-Single-threaded echo server, loopback, minimal CoAP NON GET (6 bytes):
+Echo server on loopback, minimal CoAP NON GET (6 bytes):
 
-```
-zig build bench -Doptimize=ReleaseFast -- --count 1000000
-```
+**Single-threaded** (`--count 1000000 --warmup 10000 --window 256`):
 
 | Metric | Value |
 |--------|-------|
-| Throughput | ~800K req/s |
-| Avg latency | ~320µs |
-| p50 latency | ~285µs |
-| p99 latency | ~660µs |
-| p99.9 latency | ~1000µs |
+| Throughput | 841K req/s |
+| Avg latency | 304µs |
+| p50 / p99 / p99.9 | 291µs / 496µs / 874µs |
 | Packet loss | 0% |
 
-These numbers reflect single-threaded performance on loopback, where the
-kernel's UDP stack is the bottleneck. With `--threads N` on a multi-core
-machine with a real NIC (RSS distributing across queues), throughput scales
-with core count.
+**Multi-threaded** (`--count 1000000 --warmup 10000 --threads 20 --window 64`):
+
+| Metric | Value |
+|--------|-------|
+| Throughput | 2.79M req/s |
+| Avg latency | 292µs |
+| p50 / p99 / p99.9 | 286µs / 750µs / 1766µs |
+| Packet loss | 0% |
+
+Loopback numbers are bottlenecked by the kernel's UDP stack. With a real
+NIC and RSS distributing across queues, throughput scales further with
+core count.
 
 Benchmark options: `--count`, `--window`, `--payload`, `--con`,
 `--threads`, `--warmup`, `--no-server`, `--host`, `--port`.

--- a/bench/client.zig
+++ b/bench/client.zig
@@ -291,6 +291,7 @@ fn fork_server(port: u16, thread_count: u16) !posix.pid_t {
                 .buffer_count = 512,
                 .buffer_size = 1280,
                 .thread_count = thread_count,
+                .rate_limit_ip_count = 0,
             },
             echo_handler,
         ) catch std.process.exit(1);
@@ -390,9 +391,11 @@ fn run_bench(
         const n = posix.recv(fd, &recv_buf, 0) catch |err| {
             if (err == error.WouldBlock) {
                 consecutive_timeouts += 1;
-                if (total_sent >= count and consecutive_timeouts >= 3) {
+                if (consecutive_timeouts >= 3 and in_flight > 0) {
+                    // Count in-flight packets as lost and clear window.
                     result.errors += @intCast(in_flight);
-                    break;
+                    in_flight = 0;
+                    if (total_sent >= count) break;
                 }
                 continue;
             }
@@ -404,7 +407,7 @@ fn run_bench(
         };
 
         consecutive_timeouts = 0;
-        in_flight -= 1;
+        in_flight -|= 1;
         result.received += 1;
         result.bytes_received += n;
 

--- a/src/Io.zig
+++ b/src/Io.zig
@@ -70,7 +70,7 @@ pub fn deinit(io: *Io, allocator: std.mem.Allocator) void {
     }
 }
 
-/// Bind a UDP socket and register buffers with the kernel.
+/// Bind a UDP socket and provide buffers to the kernel pool.
 pub fn setup(io: *Io, port: u16, bind_address: []const u8) !void {
     const address = try std.net.Address.parseIp(bind_address, port);
 
@@ -105,9 +105,12 @@ pub fn setup(io: *Io, port: u16, bind_address: []const u8) !void {
             .len = io.buffer_size,
         };
     }
-    try io.ring.register_buffers(io.iovecs);
 
     // Provide initial buffer pool to the kernel.
+    // Note: register_buffers is intentionally not called — the server
+    // uses provided buffers (IOSQE_BUFFER_SELECT) not fixed buffer I/O,
+    // and register_buffers pins pages against RLIMIT_MEMLOCK which limits
+    // the number of io_uring instances that can run concurrently.
     _ = try io.ring.provide_buffers(
         @intFromEnum(UserData.provide_buffers),
         @ptrCast(io.buffers.ptr),


### PR DESCRIPTION
## Summary

- **Bench client hang fix**: the recv timeout break only fired when `total_sent >= count` — if the window filled with lost packets while still sending, the client spun forever. Now clears the window after 3 consecutive timeouts regardless.
- **Remove `register_buffers`**: the server uses provided buffers (`IOSQE_BUFFER_SELECT`) not fixed buffer I/O, yet `register_buffers` pinned all buffer pages against `RLIMIT_MEMLOCK` (~650KB/instance). This prevented multiple io_uring instances from running concurrently on the default 8MB memlock limit. Removing it enables all 20 threads on a standard system.
- **Disable rate limiting in benchmark server**: the embedded echo server used default rate limiting which could throttle under heavy benchmark load.
- **README**: updated with single-threaded (841K req/s) and multi-threaded (2.79M req/s) benchmark results.

## Test plan

- [x] `zig build test` passes
- [x] `zig build bench -Doptimize=ReleaseFast -- --count 10000000 --warmup 1000 --threads 16 --window 64` completes with 0% loss (~3M req/s)
- [x] Single-threaded benchmark still works
- [x] Low thread counts (2, 4, 8) all work without worker failures