### PR TITLE
Server review fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,14 @@ var state = State{};
 var server = try coapd.Server.initContext(allocator, .{}, handle, &state);
 
 fn handle(ctx: *State, request: coapd.Request) ?coapd.Response {
-    ctx.counter += 1;
+    _ = @atomicRmw(u64, &ctx.counter, .Add, 1, .monotonic);
     return coapd.Response.ok(request.payload());
 }
 ```
 
 The context pointer is type-erased internally and passed to the handler on
-every invocation.
+every invocation. When `thread_count > 1`, the context is shared across worker
+threads — use atomic operations, mutexes, or thread-local state.
 
 ### Error Handling Wrappers
 

--- a/src/Io.zig
+++ b/src/Io.zig
@@ -166,7 +166,7 @@ pub fn submit(io: *Io) !u32 {
 
 /// Return a provided buffer to the kernel pool.
 pub fn release_buffer(io: *Io, buffer_id: u16) !void {
-    std.debug.assert(buffer_id < io.buffer_count);
+    if (buffer_id >= io.buffer_count) return error.InvalidBufferId;
     const offset = @as(usize, buffer_id) * io.buffer_size;
     _ = try io.ring.provide_buffers(
         @intFromEnum(UserData.provide_buffers),

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -57,6 +57,7 @@ pub const Config = struct {
     well_known_core: ?[]const u8 = null,
     /// Number of server threads. Each gets its own socket/ring/exchange pool.
     /// Kernel distributes packets via SO_REUSEPORT.
+    /// When > 1, the handler context pointer is shared — see `initContext`.
     thread_count: u16 = 1,
     /// IPv4 address to bind. Use "127.0.0.1" for loopback only.
     bind_address: []const u8 = "0.0.0.0",
@@ -108,7 +109,7 @@ addr_recv: linux.sockaddr,
 msg_recv: linux.msghdr,
 
 // Eviction timer.
-last_eviction_ns: i128,
+last_eviction_ns: i64,
 tick_count: u64,
 
 // Server-side message ID counter for NON responses.
@@ -122,7 +123,7 @@ load_level: LoadLevel,
 buffers_outstanding: u16,
 buffers_peak: u16,
 rate_limiter: ?RateLimiter,
-tick_now_ns: i128,
+tick_now_ns: i64,
 
 /// Pre-allocated RST buffers for rate-limited/shed CON packets.
 rate_limit_rst: []u8,
@@ -142,9 +143,13 @@ pub fn init(
 /// Initialize with a typed context handler. The context pointer is
 /// type-erased internally and passed to the handler on every invocation.
 ///
+/// **Thread safety:** When `Config.thread_count > 1`, the context pointer
+/// is shared across worker threads. Mutations must use `@atomicRmw`,
+/// mutexes, or thread-local state to avoid data races.
+///
 /// ```zig
 /// fn handle(ctx: *State, req: Request) ?Response {
-///     ctx.counter += 1;
+///     _ = @atomicRmw(u64, &ctx.counter, .Add, 1, .monotonic);
 ///     return Response.ok(req.payload());
 /// }
 /// var server = try Server.initContext(allocator, .{}, handle, &state);
@@ -529,7 +534,7 @@ pub fn tick(server: *Server) !void {
     const batch_max = constants.completion_batch_max;
     var cqes: [batch_max]Cqe = std.mem.zeroes([batch_max]Cqe);
 
-    server.tick_now_ns = std.time.nanoTimestamp();
+    server.tick_now_ns = @intCast(std.time.nanoTimestamp());
 
     const count = try server.io.wait_cqes(cqes[0..], 1);
     var recv_failed = false;
@@ -570,7 +575,7 @@ pub fn tick(server: *Server) !void {
     }
 
     // Periodic exchange eviction (~every 10 seconds).
-    const eviction_interval_ns: i128 = 10 * std.time.ns_per_s;
+    const eviction_interval_ns: i64 = 10 * std.time.ns_per_s;
     if (server.tick_now_ns - server.last_eviction_ns > eviction_interval_ns) {
         const evicted = server.exchanges.evict_expired(server.tick_now_ns);
         if (evicted > 0) {
@@ -615,6 +620,13 @@ fn handle_recv(
     var raw_header: [4]u8 = .{ 0, 0, 0, 0 };
     if (recv.payload.len >= 4) {
         @memcpy(&raw_header, recv.payload[0..4]);
+    }
+
+    // Drop non-CoAP-v1 packets early.
+    if (recv.payload.len >= 1 and (recv.payload[0] >> 6) != 1) {
+        release_buffer_robust(&server.io, recv.buffer_id);
+        server.buffers_outstanding -|= 1;
+        return;
     }
 
     // Load shedding: drop new packets when critically loaded.
@@ -724,10 +736,11 @@ fn handle_recv(
                 });
             }
         }
+        const before = if (server.config.handler_warn_ns > 0) std.time.nanoTimestamp() else 0;
         const result = server.handler_fn(server.handler_context, request);
         if (server.config.handler_warn_ns > 0) {
             const after = std.time.nanoTimestamp();
-            const elapsed: u64 = @intCast(@max(0, after - server.tick_now_ns));
+            const elapsed: u64 = @intCast(@max(0, after - before));
             if (elapsed > server.config.handler_warn_ns) {
                 log.warn("slow handler: {d}ms", .{elapsed / std.time.ns_per_ms});
             }
@@ -950,7 +963,7 @@ fn send_data(
     index: usize,
 ) !void {
     const batch: usize = @min(constants.completion_batch_max, server.config.buffer_count);
-    std.debug.assert(index < batch);
+    if (index >= batch) return error.InvalidIndex;
 
     if (data.len > server.config.buffer_size) {
         log.err("response too large: {d} > {d}", .{

--- a/src/exchange.zig
+++ b/src/exchange.zig
@@ -27,7 +27,7 @@ pub const Slot = struct {
     message_id: u16,
     response_length: u16,
     /// Monotonic timestamp (ns) when exchange was completed.
-    completed_at_ns: i128,
+    completed_at_ns: i64,
     /// Index of next free slot (when state == .free).
     next_free: u16,
 };
@@ -148,7 +148,7 @@ pub fn insert(
     key: u64,
     message_id: u16,
     response_data: []const u8,
-    now_ns: i128,
+    now_ns: i64,
 ) ?u16 {
     if (exchange.free_head == empty_sentinel) {
         return null;
@@ -157,13 +157,14 @@ pub fn insert(
         return null;
     }
 
-    std.debug.assert(exchange.find(key) == null);
+    if (exchange.find(key) != null) return null;
 
     // Allocate from free list.
     const slot_idx = exchange.free_head;
     const slot = &exchange.slots[slot_idx];
     exchange.free_head = slot.next_free;
     exchange.count_active += 1;
+    // Invariant: free_head == empty_sentinel guards over-allocation above.
     std.debug.assert(exchange.count_active <= exchange.config.exchange_count);
 
     // Populate slot.
@@ -205,8 +206,8 @@ pub fn cached_response(exchange: *const Exchange, slot_idx: u16) []const u8 {
 
 /// Evict exchanges that have expired past the exchange lifetime.
 /// Returns the number of evicted exchanges.
-pub fn evict_expired(exchange: *Exchange, now_ns: i128) u16 {
-    const lifetime_ns: i128 = @as(i128, constants.exchange_lifetime_ms) *
+pub fn evict_expired(exchange: *Exchange, now_ns: i64) u16 {
+    const lifetime_ns: i64 = @as(i64, constants.exchange_lifetime_ms) *
         std.time.ns_per_ms;
     var evicted: u16 = 0;
 
@@ -382,7 +383,7 @@ test "evict expired" {
     // Insert at time 0.
     _ = pool.insert(k1, 1, "old", 0);
     // Insert at a recent time.
-    const recent: i128 = @as(i128, constants.exchange_lifetime_ms) *
+    const recent: i64 = @as(i64, constants.exchange_lifetime_ms) *
         std.time.ns_per_ms;
     _ = pool.insert(k2, 2, "new", recent);
 

--- a/src/rate_limiter.zig
+++ b/src/rate_limiter.zig
@@ -20,13 +20,13 @@ const State = enum(u8) { free, active };
 const Slot = struct {
     ip_addr: u32,
     tokens: u16,
-    last_refill_ns: i128,
+    last_refill_ns: i64,
     state: State,
     next_free: u16,
 };
 
 const empty_sentinel: u16 = 0xFFFF;
-const ns_per_sec: i128 = std.time.ns_per_s;
+const ns_per_sec: i64 = std.time.ns_per_s;
 
 slots: []Slot,
 table: []u16,
@@ -86,7 +86,7 @@ pub fn deinit(self: *RateLimiter, allocator: std.mem.Allocator) void {
 
 /// Check if a packet from `ip_addr` is allowed. Deducts one token.
 /// Returns true if allowed, false if rate-limited.
-pub fn allow(self: *RateLimiter, ip_addr: u32, now_ns: i128) bool {
+pub fn allow(self: *RateLimiter, ip_addr: u32, now_ns: i64) bool {
     const key = hash_ip(ip_addr);
 
     // Look up existing entry.
@@ -156,10 +156,10 @@ fn find_slot(self: *const RateLimiter, key: u64, ip_addr: u32) ?u16 {
     return null;
 }
 
-fn refill(self: *const RateLimiter, slot: *Slot, now_ns: i128) void {
+fn refill(self: *const RateLimiter, slot: *Slot, now_ns: i64) void {
     const elapsed = now_ns - slot.last_refill_ns;
     if (elapsed <= 0) return;
-    const new_tokens: i128 = @divFloor(elapsed * self.config.tokens_per_sec, ns_per_sec);
+    const new_tokens: i64 = @divFloor(elapsed * self.config.tokens_per_sec, ns_per_sec);
     if (new_tokens > 0) {
         const capped: u16 = @intCast(@min(
             @as(u64, self.config.burst) - slot.tokens,
@@ -170,7 +170,7 @@ fn refill(self: *const RateLimiter, slot: *Slot, now_ns: i128) void {
     }
 }
 
-fn allocate_slot(self: *RateLimiter, key: u64, ip_addr: u32, now_ns: i128) ?u16 {
+fn allocate_slot(self: *RateLimiter, key: u64, ip_addr: u32, now_ns: i64) ?u16 {
     var slot_idx: u16 = undefined;
 
     if (self.free_head != empty_sentinel) {
@@ -219,7 +219,7 @@ fn evict(self: *RateLimiter) ?u16 {
 
     // Second pass: evict oldest (smallest last_refill_ns).
     var oldest_idx: ?u16 = null;
-    var oldest_ns: i128 = std.math.maxInt(i128);
+    var oldest_ns: i64 = std.math.maxInt(i64);
     for (self.slots, 0..) |*slot, si| {
         if (slot.state == .active and slot.last_refill_ns < oldest_ns) {
             oldest_ns = slot.last_refill_ns;
@@ -297,7 +297,7 @@ test "allow basic" {
     defer rl.deinit(testing.allocator);
 
     const ip: u32 = 0x7F000001; // 127.0.0.1
-    const now: i128 = 1_000_000_000; // 1 second
+    const now: i64 = 1_000_000_000; // 1 second
 
     // First 5 requests should succeed (burst=5).
     for (0..5) |_| {
@@ -316,7 +316,7 @@ test "token refill over time" {
     defer rl.deinit(testing.allocator);
 
     const ip: u32 = 0x7F000001;
-    var now: i128 = 1_000_000_000;
+    var now: i64 = 1_000_000_000;
 
     // Exhaust tokens.
     for (0..5) |_| {
@@ -342,7 +342,7 @@ test "multiple IPs independent" {
 
     const ip1: u32 = 0x01020304;
     const ip2: u32 = 0x05060708;
-    const now: i128 = 1_000_000_000;
+    const now: i64 = 1_000_000_000;
 
     // Each IP gets its own bucket.
     try testing.expect(rl.allow(ip1, now));
@@ -362,7 +362,7 @@ test "eviction on table full" {
     });
     defer rl.deinit(testing.allocator);
 
-    const now: i128 = 1_000_000_000;
+    const now: i64 = 1_000_000_000;
 
     // Fill the table with 2 IPs.
     try testing.expect(rl.allow(0x01020301, now));
@@ -381,7 +381,7 @@ test "reset clears all state" {
     defer rl.deinit(testing.allocator);
 
     const ip: u32 = 0x7F000001;
-    const now: i128 = 1_000_000_000;
+    const now: i64 = 1_000_000_000;
 
     try testing.expect(rl.allow(ip, now));
     try testing.expect(rl.allow(ip, now));


### PR DESCRIPTION
## Summary

- Measure handler duration per-invocation instead of per-tick
- Document thread-safety for context handlers (doc + README)
- Convert hot-path `debug.assert` to error returns (`exchange.insert`, `send_data`, `Io.release_buffer`)
- Downsize `i128` timestamps to `i64` in exchange, rate_limiter, and Server (less cache pressure)
- Validate CoAP version before processing (drop non-v1 packets early)

## Test plan

- [x] `zig build test` passes
- [x] `zig build bench -Doptimize=ReleaseFast` — no regression (~858K req/s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)