### PR TITLE
server: auto-clamp buffer_count to fit RLIMIT_MEMLOCK

### DIFF
--- a/bench/client.zig
+++ b/bench/client.zig
@@ -121,7 +121,7 @@ pub fn main() !void {
                 "  port:             {d}\n" ++
                 "  embedded server:  {s}\n" ++
                 "  threads:          {d} (single: 1, multi: {d})\n" ++
-                "  server bufs:      512 × 1280B (1T), {d} × 1280B ({d}T)\n" ++
+                "  server bufs:      512 × 1280B (auto-clamped by RLIMIT_MEMLOCK)\n" ++
                 "  client window:    {d} (1T), 64 (multi)\n" ++
                 "  warmup:           {d}\n" ++
                 "  requests/scen:    {s}\n\n",
@@ -130,7 +130,6 @@ pub fn main() !void {
                 config.port,
                 if (config.embedded_server) "yes" else "no (--no-server)",
                 cpu_count, cpu_count,
-                serverBufCount(cpu_count), cpu_count,
                 config.window_size,
                 config.warmup_count,
                 count_str,
@@ -162,7 +161,7 @@ pub fn main() !void {
             if (need_restart) {
                 kill_server(&server_pid);
                 const psk: ?coap.Psk = if (s.use_dtls) bench_psk else null;
-                server_pid = try fork_server(port, srv_tc, psk, serverBufCount(srv_tc));
+                server_pid = try fork_server(port, srv_tc, psk);
                 std.Thread.sleep(150 * std.time.ns_per_ms);
                 current_group = group;
             }
@@ -656,28 +655,14 @@ fn echo_handler(request: coap.Request) ?coap.Response {
     return coap.Response.ok(request.payload());
 }
 
-/// Compute server buffer_count per thread to stay within RLIMIT_MEMLOCK
-/// (typically 8 MB). io_uring rounds ring entries to the next power of 2,
-/// so buffer_count snaps to 512 or 256 to avoid wasting locked memory on
-/// oversized rings.
-fn serverBufCount(thread_count: u16) u16 {
-    // Empirical per-thread cost at each buffer tier (bufs × 1280 + ring overhead):
-    //   512 bufs (ring 2048): ~744 KB → max ~11 threads in 8 MB
-    //   256 bufs (ring 1024): ~380 KB → max ~21 threads in 8 MB
-    const budget_kb: u32 = 8 * 1024;
-    const per_thread_kb = budget_kb / @as(u32, thread_count);
-    if (per_thread_kb >= 744) return 512;
-    return 256;
-}
-
-fn fork_server(port: u16, thread_count: u16, psk: ?coap.Psk, buf_count: u16) !posix.pid_t {
+fn fork_server(port: u16, thread_count: u16, psk: ?coap.Psk) !posix.pid_t {
     const pid = try posix.fork();
     if (pid == 0) {
         var server = coap.Server.init(
             std.heap.page_allocator,
             .{
                 .port = port,
-                .buffer_count = buf_count,
+                .buffer_count = 512,
                 .buffer_size = 1280,
                 .thread_count = thread_count,
                 .rate_limit_ip_count = 0,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -189,6 +189,38 @@ pub fn initContext(
     return init_raw(allocator, config, gen.call, @ptrCast(@constCast(context)));
 }
 
+/// Clamp buffer_count so that all io_uring instances fit within
+/// RLIMIT_MEMLOCK. Only the ring structures are locked (provided buffers
+/// are not pinned). Each ring locks approximately:
+///   SQ: ring_entries × 64 bytes (io_uring_sqe)
+///   CQ: ring_entries × 2 × 16 bytes (io_uring_cqe)
+///   ring_entries = next_pow2(buffer_count × 4)
+/// When RLIMIT_MEMLOCK is unlimited (or getrlimit fails), the requested
+/// count is returned unchanged. Minimum returned value is 4.
+fn clampBufferCount(requested: u16, thread_count: u16) u16 {
+    const rl = std.posix.getrlimit(.MEMLOCK) catch return requested;
+    if (rl.cur == linux.RLIM.INFINITY) return requested; // unlimited
+
+    const budget = rl.cur;
+    const tc: u64 = @max(1, thread_count);
+    const per_thread = budget / tc;
+
+    var candidate: u16 = requested;
+    while (candidate > 4) {
+        const ring_entries = std.math.ceilPowerOfTwo(u32, @as(u32, candidate) *| 4) catch break;
+        // SQE: 64 bytes each, CQE: 16 bytes each (2× ring_entries).
+        const locked: u64 = @as(u64, ring_entries) * 96;
+        if (locked <= per_thread) break;
+        candidate /= 2;
+    }
+    if (candidate < requested) {
+        log.info("buffer_count clamped {d} → {d} (RLIMIT_MEMLOCK {d}, {d} threads)", .{
+            requested, candidate, budget, tc,
+        });
+    }
+    return @max(candidate, 4);
+}
+
 fn init_raw(
     allocator: std.mem.Allocator,
     config_in: Config,
@@ -210,6 +242,8 @@ fn init_raw(
     if (config.cpu_affinity) |cores| {
         if (cores.len == 0) return error.InvalidConfig;
     }
+
+    config.buffer_count = clampBufferCount(config.buffer_count, config.thread_count);
 
     var io = try Io.init(
         allocator,


### PR DESCRIPTION
## Summary
- Server reads RLIMIT_MEMLOCK at init and auto-reduces `buffer_count` if io_uring ring structures would exceed the per-thread memory budget
- Only ring memory (SQ+CQ arrays) counts against the locked memory limit — provided buffers are not pinned
- Halves buffer_count in steps until it fits, minimum 4
- Logs the clamped value when adjusted, no-op when unlimited or getrlimit fails
- Removes empirical `serverBufCount()` from bench — server handles it now

## Test plan
- [x] `zig build test` passes
- [x] Full plain bench: 32T with 512 bufs, 0 errors (no clamping needed at 8MB)
- [x] Clamping log verified when budget would be exceeded