### PR TITLE
Conditional request accessors (roadmap 3.3)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,12 +134,12 @@ Important extensions beyond base CoAP.
   freshness verification — server infrastructure, application policy.
 
 ### 3.3 Conditional requests (§5.10.1-2)
-- **Status:** `[-]` options parseable, no server enforcement
+- **Status:** `[x]` done
 - **Issue:** If-Match and If-None-Match are defined in coapz but server never
   validates preconditions. No automatic 4.12 Precondition Failed.
-- **Impact:** Handlers must implement conditional logic manually.
-- **Effort:** Small for server-side pre-check. Requires ETag tracking which is
-  application-specific, so likely remains handler-assisted.
+- **Resolution:** `Request.ifMatch()`, `Request.ifNoneMatch()`, `Request.etags()`
+  accessors. `Response.preconditionFailed()` helper. Handler-driven — ETag
+  management is application-specific.
 
 ### 3.4 Size1/Size2 options
 - **Status:** `[-]` defined, not enforced

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -105,6 +105,22 @@ pub const Request = struct {
         return null;
     }
 
+    /// If-Match ETag values from the request (RFC 7252 §5.10.1).
+    /// Returns an iterator over all If-Match options.
+    pub inline fn ifMatch(self: Request) coapz.OptionIterator {
+        return self.packet.find_options(.if_match);
+    }
+
+    /// True if the request contains an If-None-Match option (RFC 7252 §5.10.2).
+    pub inline fn ifNoneMatch(self: Request) bool {
+        return self.packet.find_option(.if_none_match) != null;
+    }
+
+    /// ETag values from the request.
+    pub inline fn etags(self: Request) coapz.OptionIterator {
+        return self.packet.find_options(.etag);
+    }
+
     /// Request method (`.get`, `.post`, `.put`, `.delete`, …).
     pub inline fn method(self: Request) coapz.Code {
         return self.packet.code;
@@ -232,6 +248,11 @@ pub const Response = struct {
     /// 4.02 Bad Option.
     pub inline fn badOption() Response {
         return .{ .code = .bad_option };
+    }
+
+    /// 4.12 Precondition Failed.
+    pub inline fn preconditionFailed() Response {
+        return .{ .code = .precondition_failed };
     }
 
     /// Response with an arbitrary code and no payload.


### PR DESCRIPTION
## Summary
- `Request.ifMatch()` — iterator over If-Match ETag values
- `Request.ifNoneMatch()` — true if If-None-Match option present
- `Request.etags()` — iterator over ETag option values
- `Response.preconditionFailed()` — 4.12 Precondition Failed helper
- Handler-driven: ETag management is application-specific

## Test plan
- [x] `zig build test` — all tests pass