### PR TITLE
feat: CON observe notifications (#87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,16 @@ Set `observe_con_interval = 0` to disable CON notifications entirely
 - If the server sends a RST to any notification, the subscription is cancelled.
 - `stream.next()` returns `null` when cancelled.
 
+**Server-side cancellation:**
+
+To tell clients a resource is gone (sensor disconnected, resource deleted),
+send a non-2.xx notification. Per RFC 7641 §3.2, clients must deregister
+on error codes:
+
+```zig
+server.notify(temp_rid, coap.Response.notFound());  // 4.04 — resource gone
+```
+
 **Server-side observer eviction:**
 
 Observers are removed when:

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ defer response.deinit(allocator);
 
 ### observe — RFC 7641
 
-Subscribe to resource notifications:
+**Client — subscribe to resource notifications:**
 
 ```zig
 var stream = try client.observe(&.{
@@ -492,9 +492,8 @@ while (try stream.next(allocator)) |notification| {
 try stream.cancel();
 ```
 
-CON notifications are automatically ACKed.
-
-For zero-allocation notification processing, use `nextBuf` with a caller-provided buffer:
+CON notifications are automatically ACKed. For zero-allocation processing,
+use `nextBuf` with a caller-provided buffer:
 
 ```zig
 var buf: [1500]u8 = undefined;
@@ -503,6 +502,59 @@ while (try stream.nextBuf(&buf)) |notification| {
     std.debug.print("update: {s}\n", .{notification.payload});
 }
 ```
+
+**Server — push notifications to subscribers:**
+
+```zig
+// Allocate a resource ID at startup.
+const temp_rid = server.allocateResource() orelse return error.Full;
+
+// In the handler, register the client as an observer.
+fn handler(req: coap.Request) ?coap.Response {
+    if (req.method() == .get) {
+        _ = req.observeResource(temp_rid);
+        return coap.Response.ok("22.5");
+    }
+    return coap.Response.methodNotAllowed();
+}
+
+// From any thread, push an update to all observers.
+server.notify(temp_rid, coap.Response.ok("23.1"));
+```
+
+`notify()` is thread-safe — call it from sensor loops, worker threads,
+or interrupt handlers. Notifications are queued and sent on the next
+server tick.
+
+**Reliability — CON notifications:**
+
+The server periodically sends CON (confirmable) notifications to verify
+that observers are still reachable. The interval is configurable:
+
+```zig
+.observe_con_interval = 20,  // every 20th notification is CON (default)
+```
+
+When a CON notification goes unacknowledged after retransmission (exponential
+backoff, up to 4 retries per RFC 7252 §4.2), the observer is automatically
+removed. This is how the server detects that a client has gone away.
+
+Set `observe_con_interval = 0` to disable CON notifications entirely
+(all notifications sent as NON). Set to `1` for maximum reliability
+(every notification is CON, higher overhead).
+
+**Client-side cancellation and failure detection:**
+
+- Call `stream.cancel()` to unsubscribe (sends Observe=1 deregister).
+- If the server sends a RST to any notification, the subscription is cancelled.
+- `stream.next()` returns `null` when cancelled.
+
+**Server-side observer eviction:**
+
+Observers are removed when:
+- The client sends RST to a notification (explicit rejection).
+- A CON notification times out after max retransmissions (client unreachable).
+- The handler calls `req.removeObserver(rid)` explicitly.
 
 ### upload — RFC 7959 Block1
 
@@ -534,6 +586,7 @@ var server = try coap.Server.init(allocator, .{
     .max_block_payload = 64 * 1024,   // max block transfer payload (bytes)
     .max_observers = 256,             // max total observer entries
     .max_observe_resources = 64,      // max observed resources
+    .observe_con_interval = 20,       // CON every Nth notification (0 = NON only)
     .well_known_core = null,          // RFC 6690 discovery payload
     .recognized_options = &.{},       // extra critical options to allow
     .thread_count = 1,                // server threads (SO_REUSEPORT)
@@ -614,6 +667,13 @@ Default: `65536` (64 KB).
 Maximum total observer entries and maximum observed resources for server-side
 Observe (RFC 7641). The observer list is partitioned evenly across resources.
 Set `max_observers` to `0` to disable. Defaults: `256` / `64`.
+
+### `observe_con_interval`
+
+Send a CON (confirmable) notification every N notifications per observer.
+CON notifications require client acknowledgement — unresponsive observers
+are removed after retransmission timeout. Set to `0` to send NON only.
+Default: `20`.
 
 ### `well_known_core`
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -66,6 +66,9 @@ pub const Config = struct {
     max_observers: u16 = 256,
     /// Maximum observed resources.
     max_observe_resources: u16 = 64,
+    /// Send a CON notification every N notifications per observer (RFC 7641 §4.5).
+    /// 0 = always NON (disable CON notifications).
+    observe_con_interval: u16 = 20,
     /// Link-format payload for GET /.well-known/core (RFC 6690).
     /// If null, requests pass through to the handler.
     well_known_core: ?[]const u8 = null,
@@ -790,8 +793,9 @@ pub fn tick(server: *Server) !void {
     // Drain deferred response queue and retransmit pending CONs.
     server.drainDeferred();
 
-    // Drain observe notification queue — send NON to all observers.
+    // Drain observe notification queue and retransmit pending CONs.
     server.drainNotifications();
+    server.retransmitObserveCons();
 
     // Compute load level based on buffer/exchange pool utilization.
     server.update_load_level();
@@ -932,6 +936,10 @@ fn handle_recv(
             if (pool.findByMsgId(packet.msg_id, recv.peer_address)) |idx| {
                 pool.release(idx);
             }
+        }
+        // ACK for a CON observe notification — clear pending state.
+        if (server.observers) |*reg| {
+            reg.ackConNotification(packet.msg_id, recv.peer_address);
         }
         return;
     }
@@ -2115,7 +2123,7 @@ fn drainNotifications(server: *Server) void {
         if (entry.response_len == 0) continue;
         const notify_buf = reg.notifyBuf(entry.queue_slot);
         const meta_data = notify_buf[0..entry.response_len];
-        const obs_list = reg.getObservers(entry.resource_id);
+        const obs_list = reg.getObserversMut(entry.resource_id);
 
         const meta = ObserverRegistry.decodeNotifyMeta(meta_data, arena) orelse continue;
 
@@ -2124,28 +2132,82 @@ fn drainNotifications(server: *Server) void {
         meta.options[0] = coapz.Option.uint(.observe, meta.obs_seq, &obs_val_buf);
 
         var sent: usize = 0;
+        const con_interval = server.config.observe_con_interval;
         for (obs_list) |*obs| {
             if (!obs.active) continue;
+            // Skip observers with an outstanding CON (wait for ACK/timeout).
+            if (obs.pending_con_msg_id != 0) continue;
+
+            obs.notify_count +%= 1;
+            const use_con = con_interval > 0 and (obs.notify_count % con_interval == 0);
+            const msg_id = server.nextMsgId();
+
             const pkt = coapz.Packet{
-                .kind = .non_confirmable,
+                .kind = if (use_con) .confirmable else .non_confirmable,
                 .code = meta.code,
-                .msg_id = server.nextMsgId(),
+                .msg_id = msg_id,
                 .token = obs.token[0..obs.token_len],
                 .options = meta.options,
                 .payload = meta.payload,
                 .data_buf = &.{},
             };
             const buf_idx = sent % batch;
-            if (server.dtls_sessions) |tbl| {
+            const wire: ?[]const u8 = if (server.dtls_sessions) |tbl| blk: {
                 if (tbl.lookup(obs.peer_address)) |session| {
-                    _ = server.send_dtls_packet(session, pkt, obs.peer_address, buf_idx) catch continue;
-                    sent += 1;
-                    continue;
+                    break :blk server.send_dtls_packet(session, pkt, obs.peer_address, buf_idx) catch continue;
                 }
+                break :blk null;
+            } else null;
+            const wire_data = wire orelse (server.send_packet(pkt, obs.peer_address, buf_idx) catch continue);
+
+            if (use_con) {
+                // Cache for retransmission and dedup.
+                const addr_key = Exchange.addrHash(obs.peer_address);
+                const key = Exchange.peerKey(obs.peer_address, msg_id);
+                _ = server.exchanges.insert(key, addr_key, msg_id, wire_data, server.tick_now_ns);
+                obs.pending_con_msg_id = msg_id;
+                obs.retransmit_count = 0;
+                const timeout_ms: i64 = @intCast(constants.ack_timeout_ms);
+                obs.retransmit_deadline_ns = server.tick_now_ns + timeout_ms * std.time.ns_per_ms;
             }
-            _ = server.send_packet(pkt, obs.peer_address, buf_idx) catch continue;
             sent += 1;
         }
+    }
+}
+
+/// Retransmit outstanding CON observe notifications and evict timed-out observers.
+fn retransmitObserveCons(server: *Server) void {
+    const reg = &(server.observers orelse return);
+    const batch: usize = @min(constants.completion_batch_max, server.config.buffer_count);
+
+    for (reg.observers) |*obs| {
+        if (!obs.active or obs.pending_con_msg_id == 0) continue;
+        if (server.tick_now_ns < obs.retransmit_deadline_ns) continue;
+
+        obs.retransmit_count += 1;
+        if (obs.retransmit_count > constants.max_retransmit) {
+            // Timeout — remove observer (RFC 7641 §4.5).
+            log.debug("observe CON timeout, removing observer", .{});
+            obs.active = false;
+            obs.pending_con_msg_id = 0;
+            continue;
+        }
+
+        // Retransmit from exchange cache.
+        const key = Exchange.peerKey(obs.peer_address, obs.pending_con_msg_id);
+        if (server.exchanges.find(key)) |slot_idx| {
+            const cached = server.exchanges.cachedResponse(slot_idx);
+            const idx = @as(usize, obs.retransmit_count) % batch;
+            server.send_data(cached, obs.peer_address, idx) catch {};
+        } else {
+            // Cache evicted — give up on this CON.
+            obs.pending_con_msg_id = 0;
+            continue;
+        }
+
+        const backoff: u5 = @intCast(@min(obs.retransmit_count, constants.max_retransmit));
+        const timeout_ms: i64 = @as(i64, constants.ack_timeout_ms) << backoff;
+        obs.retransmit_deadline_ns = server.tick_now_ns + timeout_ms * std.time.ns_per_ms;
     }
 }
 

--- a/src/dtls/integration_test.zig
+++ b/src/dtls/integration_test.zig
@@ -363,6 +363,70 @@ test "Observe: notification carries correct client token" {
     try testing.expectEqualSlices(u8, expected_token, notif.packet.token);
 }
 
+test "Observe: CON notification with ACK" {
+    const port: u16 = 19776;
+
+    var server = try Server.init(testing.allocator, .{
+        .port = port,
+        .buffer_count = 16,
+        .buffer_size = 1280,
+        .exchange_count = 16,
+        .rate_limit_ip_count = 0,
+        .max_observers = 16,
+        .max_observe_resources = 4,
+        .observe_con_interval = 1, // Every notification is CON.
+    }, observeRegHandler);
+    defer server.deinit();
+
+    const rid = server.allocateResource() orelse return error.NoResource;
+    observe_resource_id = rid;
+
+    try server.listen();
+
+    var runner = ServerRunner{ .server = &server };
+    const server_thread = try std.Thread.spawn(.{}, ServerRunner.run, .{&runner});
+    defer runner.stop(server_thread);
+
+    var client = try Client.init(testing.allocator, .{
+        .host = "127.0.0.1",
+        .port = port,
+        .max_in_flight = 4,
+    });
+    defer client.deinit();
+
+    var path_buf: [1]coapz.Option = .{coapz.Option{ .kind = .uri_path, .value = "temp" }};
+    var stream = try client.observe(&path_buf);
+
+    // Push CON notification.
+    server.notify(rid, handler.Response{
+        .code = .content,
+        .payload = "23.0",
+        .options = &.{},
+    });
+
+    // Receive notification (client auto-ACKs CON).
+    const NextCtx = struct {
+        stream: *Client.ObserveStream,
+        result: ?Client.ObserveStream.Notification = null,
+        fn run(self: *@This()) void {
+            self.result = self.stream.next(testing.allocator) catch null;
+        }
+    };
+    var next_ctx = NextCtx{ .stream = &stream };
+    const next_thread = try std.Thread.spawn(.{}, NextCtx.run, .{&next_ctx});
+
+    std.Thread.sleep(300 * std.time.ns_per_ms);
+    stream.cancel() catch {};
+    next_thread.join();
+
+    // Should have received a notification (token check proves delivery).
+    const notif = next_ctx.result orelse return error.NoNotification;
+    defer notif.deinit(testing.allocator);
+
+    const sub = &client.observes[0];
+    try testing.expectEqualSlices(u8, sub.token[0..sub.token_len], notif.packet.token);
+}
+
 const Deferred = @import("../deferred.zig");
 
 var dtls_deferred_handle: ?Deferred.DeferredResponse = null;

--- a/src/observe.zig
+++ b/src/observe.zig
@@ -27,6 +27,12 @@ pub const Observer = struct {
     peer_address: std.net.Address,
     token: [8]u8,
     token_len: u8,
+    /// Notifications sent to this observer (for CON interval).
+    notify_count: u16 = 0,
+    /// Non-zero when a CON notification is outstanding.
+    pending_con_msg_id: u16 = 0,
+    retransmit_count: u4 = 0,
+    retransmit_deadline_ns: i64 = 0,
 };
 
 pub const Resource = struct {
@@ -158,6 +164,10 @@ pub fn addObserver(self: *ObserverRegistry, resource_id: u16, peer: std.net.Addr
             obs.token_len = @intCast(@min(token.len, 8));
             obs.token = .{0} ** 8;
             @memcpy(obs.token[0..obs.token_len], token[0..obs.token_len]);
+            obs.notify_count = 0;
+            obs.pending_con_msg_id = 0;
+            obs.retransmit_count = 0;
+            obs.retransmit_deadline_ns = 0;
             _ = self.resources[resource_id].observer_count.fetchAdd(1, .monotonic);
             return true;
         }
@@ -201,6 +211,12 @@ pub fn removeByPeer(self: *ObserverRegistry, peer: std.net.Address) void {
 
 /// Get the observer list for a resource (for tick loop to iterate).
 pub fn getObservers(self: *const ObserverRegistry, resource_id: u16) []const Observer {
+    const base = @as(usize, resource_id) * self.observers_per_resource;
+    return self.observers[base..][0..self.observers_per_resource];
+}
+
+/// Mutable version for tick-loop use (CON notification state updates).
+pub fn getObserversMut(self: *ObserverRegistry, resource_id: u16) []Observer {
     const base = @as(usize, resource_id) * self.observers_per_resource;
     return self.observers[base..][0..self.observers_per_resource];
 }
@@ -290,6 +306,18 @@ pub fn notifyData(self: *const ObserverRegistry, slot_idx: u16) []const u8 {
 pub fn notifyBuf(self: *const ObserverRegistry, slot: u16) []u8 {
     const offset = @as(usize, slot) * self.config.buffer_size;
     return self.notify_buffer[offset..][0..self.config.buffer_size];
+}
+
+/// Clear pending CON state when an ACK is received for a CON notification.
+pub fn ackConNotification(self: *ObserverRegistry, msg_id: u16, peer: std.net.Address) void {
+    for (self.observers) |*obs| {
+        if (!obs.active) continue;
+        if (obs.pending_con_msg_id != msg_id) continue;
+        if (!addrEqual(obs.peer_address, peer)) continue;
+        obs.pending_con_msg_id = 0;
+        obs.retransmit_count = 0;
+        return;
+    }
 }
 
 pub const NotifyMeta = struct {


### PR DESCRIPTION
## Summary

- Add `observe_con_interval` config (default 20) — every Nth notification per observer is CON
- CON notifications cached in exchange table for dedup and retransmission
- Exponential backoff retransmit with observer eviction on timeout (RFC 7641 §4.5)
- ACK matching clears pending CON state
- Observers with outstanding CON skipped until ACK or timeout
- New fields on Observer: `notify_count`, `pending_con_msg_id`, `retransmit_count`, `retransmit_deadline_ns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)